### PR TITLE
add Replace for use instead the original library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,9 @@
   "require-dev": {
     "phpunit/phpunit": "*"
   },
+  "replace": {
+    "pear/html_quickform": "*"
+  },
   "autoload": {
     "classmap": [
       "./HTML"


### PR DESCRIPTION
Hi,
Thanks for your work. I need this library but I cannot replace the require into all thrid-party libraries.

This configuration allow composer to use this library in place of the original library without need to change the require in all `composer.json` files.

Please tag a new version after merging.

Thanks in advance.